### PR TITLE
Adding backwards history search

### DIFF
--- a/.inputrc
+++ b/.inputrc
@@ -1,0 +1,7 @@
+# This allows you to search through your history using the up and down arrows …
+# i.e. type "cd /" and press the up arrow and you'll search through everything in your history that starts with "cd /"
+# Credit: https://coderwall.com/p/oqtj8w
+"\e[A": history-search-backward
+"\e[B": history-search-forward
+set show-all-if-ambiguous on
+set completion-ignore-case on


### PR DESCRIPTION
I've added 'The most useful thing in bash' from https://coderwall.com/p/oqtj8w

This allows you to search through your history using the up and down arrows … i.e. type "cd /" and press the up arrow and you'll search through everything in your history that starts with "cd /".